### PR TITLE
Revert "feat: change sorting of container children within CType `menu_section`"

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,16 +1,1 @@
 @import 'EXT:headless_container/Configuration/TypoScript/ContentElement/*.typoscript'
-
-# More advanced sorting of elements within CType 'menu_section' so container children are
-# being put right after their parents.
-# Inspired by http://blog.sitegefuehl.de/typo3-inhaltsverzeichnis-section-index-gridelements/
-tt_content.menu_section.fields.content.fields.menu.dataProcessing.10.dataProcessing.20 {
-    where = tt_content.sectionIndex = 1
-    selectFields (
-        tt_content.uid, tt_content.header, tt_content.sys_language_uid, tt_content.l18n_parent,
-        ((IFNULL(container.sorting, tt_content.sorting) * 100000000) +
-         (tt_content.tx_gridelements_columns * 10000) +
-         tt_content.sorting) as customSorting
-    )
-    leftjoin = tt_content AS container ON container.uid = tt_content.tx_container_parent
-    orderBy = customSorting
-}


### PR DESCRIPTION
Phew, I don't know why I thought this patch was necessary, but it's not. And it's kaputt too (due to reference to a gridelements column). Please revert!

Reverts itplusx/headless-container#3