### PR TITLE
[BUGFIX] Use contentPid in getColPosList()

### DIFF
--- a/Classes/UserFunctions/GridRecords.php
+++ b/Classes/UserFunctions/GridRecords.php
@@ -33,7 +33,7 @@ final class GridRecords
             ->where(
                 $queryBuilder->expr()->eq(
                     'pid',
-                    $queryBuilder->createNamedParameter($GLOBALS['TSFE']->id, \PDO::PARAM_INT)
+                    $queryBuilder->createNamedParameter($GLOBALS['TSFE']->contentPid, \PDO::PARAM_INT)
                 ),
                 $queryBuilder->expr()->gt(
                     'tx_container_parent',


### PR DESCRIPTION
When a page renders content of another page, then the other page must be used to build the colPos list.

The TSFE variable $contentPid defaults to $id and is different to $id, when the page renders content of another page.

See https://github.com/TYPO3/typo3/blob/main/typo3/sysext/frontend/Classes/Controller/TypoScriptFrontendController.php#L159