### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "php": "^8.1",
     "typo3/cms-core": "^12.4 || ^13.4",
-    "b13/container": "^2.0 || <3.1.2",
+    "b13/container": ">=2.0.0 <3.1.2",
     "friendsoftypo3/headless": "^4.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "php": "^8.1",
     "typo3/cms-core": "^12.4 || ^13.4",
-    "b13/container": "^2.0 || ^3.0",
+    "b13/container": "^2.0 || <3.1.2",
     "friendsoftypo3/headless": "^4.0"
   },
   "autoload": {


### PR DESCRIPTION
Container got updatet in 3.1.2 they redo the ContainerProcessor and it breaks the headless-container Processor.  To prevent breaking in production. I add a strict Version constrain to the composer.json.

after that, we should go to v3 with headless-container and depend on container > 3.1.2 to make clear that here is a breaking change.