### PR TITLE
fix: Adapt getColPosList() where content_from_pid is set

### DIFF
--- a/Classes/UserFunctions/GridRecords.php
+++ b/Classes/UserFunctions/GridRecords.php
@@ -31,7 +31,13 @@ final class GridRecords
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
         $currentContentObject = $request->getAttribute('currentContentObject');
-        $pid = $currentContentObject->data['uid'];
+
+        if ($currentContentObject->data['content_from_pid']) {
+            $pid = $currentContentObject->data['content_from_pid'];
+        } else {
+            $pid = $currentContentObject->data['uid'];
+        }
+
         $result = $queryBuilder
             ->select('colPos','pid', 'tx_container_parent')
             ->from('tt_content')


### PR DESCRIPTION
On pages where `content_from_pid` is given colPos > 0 is rendered into JSON and thus behaves different than on other pages. 

For now this is only fixed for v2.x branch but might be relevant for newer versions as well.